### PR TITLE
Limpeza do repositório: mantém apenas README.md e my-tasks.txt

### DIFF
--- a/pretalab-ciclo14-git-github/.gitignore
+++ b/pretalab-ciclo14-git-github/.gitignore
@@ -1,0 +1,4 @@
+*
+!.gitignore
+!README.md
+!my-tasks.txt


### PR DESCRIPTION
Este PR remove arquivos não relacionados ao exercício de Git e Github,
mantendo apenas os arquivos necessários para a atividade prática:

- README.md → com a descrição das aulas
- my-tasks.txt → com as tarefas diárias
- .gitignore → configurado para ignorar outros arquivos

Objetivo: deixar o repositório limpo e focado apenas no que foi solicitado
na atividade do Ciclo 14 da Pretalab.
